### PR TITLE
Added Cargo.toml fields to ensure compliance with guidelines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "ArmorLib"
+description = "Easily scan files for threats to security and privacy."
 version = "0.1.0"
 authors = ["Miles McCain <libre@rmrm.io>"]
+readme = "README.MD"
+license = "Apache-2.0"
+keywords = ["os", "security", "steganography", "malware"]
+categories = ["command-line-utilities", "os", "filesystem"]
+repository = "https://github.com/milesmcc/ArmorLib"
 
 [dependencies]


### PR DESCRIPTION
The Rust API guidelines have an explicit rule,
[C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata), that Cargo.toml should have common metadata fields. I've simply added those. This ensures that, upon publishing, users can easily find the crate and understand what it does and how it works specifically.